### PR TITLE
Fix and improvement

### DIFF
--- a/lib/gtags-files.coffee
+++ b/lib/gtags-files.coffee
@@ -2,18 +2,26 @@
 module.exports =
 class GtagsFiles
   @subscription: null
+  @preivew_counter: 0
   @events: []
   @paths: []
   @keepOpened: []
 
   @preview: (path, line, keepOpened=0) ->
-    GtagsFiles.subscription = atom.workspace.onDidOpen (event) =>
-      if event?['uri'] not in @paths
-        # console.log "push"
-        # console.log event
-        GtagsFiles.events.push event
-        GtagsFiles.paths.push event['uri']
-      GtagsFiles.subscription.dispose()
+    if(GtagsFiles.subscription==null)
+      @preivew_counter = 1
+      GtagsFiles.subscription = atom.workspace.onDidOpen (event) =>
+        if event?['uri'] not in @paths
+          # console.log "push"
+          # console.log event
+          GtagsFiles.events.push event
+          GtagsFiles.paths.push event['uri']
+        @preivew_counter -= 1
+        return if @preivew_counter > 0
+        GtagsFiles.subscription.dispose()
+        GtagsFiles.subscription = null
+    else
+      @preivew_counter += 1
 
     if keepOpened is 1
       # console.log "keep #{path}"

--- a/lib/gtags-files.coffee
+++ b/lib/gtags-files.coffee
@@ -19,12 +19,12 @@ class GtagsFiles
       # console.log "keep #{path}"
       GtagsFiles.keepOpened.push path
 
-    atom.workspace.open(path,{activatePane:false}).done =>
+    atom.workspace.open(path,{activatePane:false}).then =>
       GtagsFiles.moveToLine(line)
 
   @open: (path, line) ->
     GtagsFiles.keepOpened.push path
-    atom.workspace.open(path,{activatePane:true}).done =>
+    atom.workspace.open(path,{activatePane:true}).then =>
       GtagsFiles.moveToLine(line)
     GtagsFiles.clear()
 

--- a/lib/gtags-navigation.coffee
+++ b/lib/gtags-navigation.coffee
@@ -140,7 +140,7 @@ class GtagsNavigation
       return GtagsNavigation.curIndex[id]
 
   @openPath: (path, position, id=1) ->
-    atom.workspace.open(path).done => GtagsNavigation.moveToLine(position, id)
+    atom.workspace.open(path).then => GtagsNavigation.moveToLine(position, id)
       #console.log GtagsNavigation.trace
 
   @moveToLine: (position, id) ->

--- a/lib/gtags-symbols-view.coffee
+++ b/lib/gtags-symbols-view.coffee
@@ -37,8 +37,10 @@ class GtagsSymbolsView extends SelectListView
 
   confirmed: (item) ->
 
+    @isConfirmed = true
     if item['title']?
       console.log "===>>> title selected"
+      @cancel()
     else
       console.log("===>>> #{item['path']}:#{item['line']} was selected")
       GtagsNavigation.unlock()
@@ -46,8 +48,6 @@ class GtagsSymbolsView extends SelectListView
       GtagsNavigation.add(item['path'], item['line'], "")
       GtagsFiles.open(item['path'], item['line'])
 
-    @isConfirmed = true
-    @cancel()
 
   selectItemView: (view) ->
       super

--- a/lib/gtags-symbols-view.coffee
+++ b/lib/gtags-symbols-view.coffee
@@ -78,7 +78,7 @@ class GtagsSymbolsView extends SelectListView
       @prePath = textEditor.getPath()
       @prePosition = textEditor.getCursorBufferPosition()
       GtagsNavigation.add(@prePath, @prePosition['row']+1, "")
-    atom.workspace.open(path).done => @moveToLine(line)
+    atom.workspace.open(path).then => @moveToLine(line)
     # add new path
     GtagsNavigation.add(path, line, "")
 

--- a/lib/gtags-symbols-view.coffee
+++ b/lib/gtags-symbols-view.coffee
@@ -29,7 +29,8 @@ class GtagsSymbolsView extends SelectListView
           @div "Project: #{item['project']}", class: 'secondary-line'
         else
           @div "#{item['signature']}", class: 'primary-line'
-          @div "#{Path.basename(item['path'])} @ #{item['path']}: #{item['line']}", class: 'secondary-line'
+          item_path = if atom.config.get('atom-gtags.useRelativePath') then item['relative_path'] else item['path']
+          @div "#{Path.basename(item['path'])} @ #{item_path}: #{item['line']}", class: 'secondary-line'
 
   getFilterKey: ->
     # console.log "getFilterKey: #{@filterKey}"

--- a/lib/gtags-symbols.coffee
+++ b/lib/gtags-symbols.coffee
@@ -1,6 +1,7 @@
 
 Path = require 'path'
 fs = require 'fs'
+extend = require('util')._extend
 PathToGtags = ""
 PathToGlobal = ""
 GtagsEnv = null
@@ -23,7 +24,7 @@ class GtagsSymbols
       packageRoot  = @getPackageRoot()
       PathToGtags  = Path.join(packageRoot, 'vendor', "#{process.platform}", "gtags")
       PathToGlobal = Path.join(packageRoot, 'vendor', "#{process.platform}", "global")
-      GtagsEnv = @clone(process.env)
+      GtagsEnv = extend({}, process.env)
       GtagsEnv['PATH'] = Path.join(packageRoot, 'vendor', "#{process.platform}")
       BuildCmdByOptions["--update"] = PathToGlobal
       BuildCmdByOptions["--sqlite3"] = PathToGtags

--- a/lib/gtags-symbols.coffee
+++ b/lib/gtags-symbols.coffee
@@ -8,10 +8,10 @@ GtagsEnv = null
 BuildCmdByOptions = {}
 
 FilterKeyByOptions =
-  "-ax": "path"
-  "-axr": "path"
-  "-axf": "symbol"
-  "-axc": "symbol"
+  "-x": "path"
+  "-xr": "path"
+  "-xf": "symbol"
+  "-xc": "symbol"
 
 
 module.exports =
@@ -30,13 +30,13 @@ class GtagsSymbols
 
   # Public
   getDefinitions: (symbolName, symbolFile="") ->
-    return @gtagsCommand("-ax", symbolName)
+    return @gtagsCommand("-x", symbolName)
 
   getReferences: (symbolName, symbolFile="") ->
-    return @_gtagsCommand("-axr", symbolName, Path.dirname(symbolFile))
+    return @_gtagsCommand("-xr", symbolName, Path.dirname(symbolFile))
 
   getSymbolsOfFile: (path) ->
-    return @_gtagsCommand("-axf", path, Path.dirname(path))
+    return @_gtagsCommand("-xf", path, Path.dirname(path))
 
   singleFileUpdate: (path) ->
     {symbols, status} = @_gtagsCommand("-p", "", Path.dirname(path))
@@ -52,7 +52,7 @@ class GtagsSymbols
       return {'symbols': {}, 'status': {}}
 
   getCompletions: (prefix) ->
-    return @gtagsCommand("-axc", prefix)
+    return @gtagsCommand("-xc", prefix)
 
   buildTags: (path, onCompleted=null) ->
     return @_buildTags("build", path, onCompleted)
@@ -92,6 +92,10 @@ class GtagsSymbols
       if @hasTagsFile(path)
         {symbols, status} = @_gtagsCommand(options, arg, path)
         if symbols?.length > 0
+          for sym in symbols
+            relative_path = sym['path']
+            sym['path'] = "#{path}/#{relative_path}"
+            sym['relative_path'] = relative_path
           syms.push(symbols...)
           stas = status
           console.log symbols
@@ -123,7 +127,7 @@ class GtagsSymbols
 
     symbols = global.stdout.toString().match(/[^\r\n]+/g)
     console.log symbols
-    if options is "-axc"
+    if options is "-xc"
       for s in symbols
         result.push({"symbol":s})
       return {'symbols': result, 'status': {}}

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -21,6 +21,10 @@ module.exports = AtomGtags =
       type: 'boolean'
       default: true
 
+    useRelativePath:
+      type: 'boolean'
+      default: true
+
   provider: null
   gtagsListView: null
   modalPanel: null


### PR DESCRIPTION
Hi, thanks for your great work on this package :smile: In my daily use of this package, I have encountered some problems and finally solved them. Here's the summary:
### 1.Fix the deprecated warning in Promise.done() d1fef2d3cc7832f3c8f4274bf6234182a35e700c
Promise.done()   has been deprecated in recent Atom version:
```javascript
# Preserve this deprecation until 2.0. Sorry. Should have removed Q sooner.
Promise.prototype.done = (callback) ->
  deprecate("Atom now uses ES6 Promises instead of Q. Call promise.then instead of promise.done")
  @then(callback)
```

### 2.Fix GtagsSymbolsView's double cancel issue 0883e5dbbeda0025fc0bcfd5b4ef76edd2264744
SelectListView will get a `blur` event as the `GtagsFiles.open()` activates the pane, which causes the list losing focus. And the SelectListView's `blur` callback calls the cancel().
```javascript
@filterEditorView.on 'blur', (e) =>
  @cancel() unless @cancelling
```
So we do not need to call cancel() here any more.


### 3.Add a useRelativePath option in Package Settings b24eb299a341dff3f94f32571ab3be635d568f2f 
Sometimes the file path of searching result is too long for the list to show. For example:
![screenshot from 2017-05-06 19-16-40](https://cloud.githubusercontent.com/assets/5461336/25771923/e5f8ed14-3290-11e7-9ce5-bea8552a95fe.png)
So I add an option to only show the relative path in the result list:
![screenshot from 2017-05-06 19-21-26](https://cloud.githubusercontent.com/assets/5461336/25771940/3faa08ca-3291-11e7-81a1-435d4b3d8638.png)

### 4.Change GtagsEnv to extend process.env rather than clone e7919f410cf539b83377b45357d6ac3a67ec8f99
The value assignment of cloned object will also change `process.env`, because they are sharing the same process level variable (current process's enviroment). See test below:
![image](https://cloud.githubusercontent.com/assets/5461336/25779075/80d1ea50-3342-11e7-913e-9c354e3c165d.png)

So we just need to extend a object that has same properties with process.env here:
![image](https://cloud.githubusercontent.com/assets/5461336/25779085/bdec5c22-3342-11e7-8a1b-feb5e4c9f615.png)


### 5.Fix a race condition in GtagsFile.preview() 79a0ec1e6cd85a184fc92a1293b200faceaa7184
If the `GtagsFile.preview` is called twice in such a short time that the first subscription **isn't invoked**. Then the latter call will `override` GtagsFiles.subscription, which causes the former never be disposed().